### PR TITLE
PythonのDockerfileを追加

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,3 +5,5 @@ services:
       dockerfile: Dockerfile
     container_name: mosaic_python
     tty: true
+    volumes:
+      - "./python/src:/usr/src/app"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  python:
+    build:
+      context: ./python
+      dockerfile: Dockerfile
+    container_name: mosaic_python
+    tty: true

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,0 +1,4 @@
+FROM python:3.11
+WORKDIR /usr/src/app
+
+RUN pip install opencv-python fastapi gunicorn


### PR DESCRIPTION
Docker周りの実装になります。まずはAPサーバー側から。
OpenCVの関係でPythonは3.11系を採用しています。

参考：https://pypi.org/project/opencv-python/