### PR TITLE
FastAPIの導入&モザイクフィルターAPIの実装

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -6,4 +6,4 @@ RUN apt-get upgrade -y
 RUN apt-get install -y libgl1-mesa-dev
 RUN pip install opencv-python fastapi uvicorn[standard]
 
-RUN uvicorn route:app --host 0.0.0.0 --reload --port 8000
+CMD ["uvicorn", "route:app", "--host", "0.0.0.0", "--reload", "--port", "8000"]

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -4,4 +4,4 @@ WORKDIR /usr/src/app
 RUN apt-get update
 RUN apt-get upgrade -y
 RUN apt-get install -y libgl1-mesa-dev
-RUN pip install opencv-python fastapi gunicorn
+RUN pip install opencv-python fastapi uvicorn[standard]

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -5,3 +5,5 @@ RUN apt-get update
 RUN apt-get upgrade -y
 RUN apt-get install -y libgl1-mesa-dev
 RUN pip install opencv-python fastapi uvicorn[standard]
+
+RUN uvicorn route:app --host 0.0.0.0 --reload --port 8000

--- a/python/src/route.py
+++ b/python/src/route.py
@@ -1,0 +1,19 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from image import base64_to_ndarray, mosaic_image, ndarray_to_base64
+
+app = FastAPI()
+
+class filterParametars(BaseModel):
+    base64_str: str
+    start_x_position: int
+    start_y_position: int
+    width: int
+    height: int
+
+@app.post("/v1/filter/mosaic")
+async def mosaic_fileter(param: filterParametars):
+    image_ndarray = base64_to_ndarray(param.base64_str)
+    modified_image = mosaic_image(image_ndarray, param.start_x_position ,param.start_y_position ,param.width,param.height)
+    base64_str = ndarray_to_base64(modified_image)
+    return {"image_base64": base64_str}


### PR DESCRIPTION
モザイクフィルターAPIの実装を行いました。
Web側からBase64にした画像とモザイク処理の指定に必要な数値を受け取って、Base64のフィルター適用済みの画像を返却するAPIです。

ローカルでcurlなどで確認するときはBase64文字列がとても長いため、ファイルにPOSTするデータのjsonを書いて投げた方がよいです。