### PR TITLE
モザイクフィルターAPIへのリクエスト処理の実装

### DIFF
--- a/nginx/src/index.html
+++ b/nginx/src/index.html
@@ -53,9 +53,52 @@
         function mouseUp(event) {
             // 元の画像ファイルを再描画してマウス移動時に描画していた選択範囲を消去
             context.drawImage(image, 0, 0);
+            // モザイクフィルターAPIへリクエスト
+            postFilter();
+            // 選択範囲のリセット
             rectanglePosition = {x1: 0, y1: 0, x2: 0, y2: 0};
             canvas.removeEventListener("mousemove", mouseMove);
         }
         canvas.addEventListener("mouseup", mouseUp);
+
+        function postFilter() {
+            // x座標は右へマウスを動かした時はそのままの値でよいが左に動かした時は計算が必要
+            if (rectanglePosition.x2 > 0) {
+                startXPosition = rectanglePosition.x1;
+                width = rectanglePosition.x2;
+            } else {
+                startXPosition = rectanglePosition.x1 + rectanglePosition.x2;
+                width = rectanglePosition.x2 * -1;
+            }
+            // y座標についても同様の計算を行う
+            if (rectanglePosition.y2 > 0) {
+                startYPosition = rectanglePosition.y1;
+                height = rectanglePosition.y2;
+            } else {
+                startYPosition = rectanglePosition.y1 + rectanglePosition.y2;
+                height = rectanglePosition.y2 * -1;
+            }
+            // 'data:image/png;base64,Base64文字列の形式のためsplitしてBase64文字列のみ取り出す'
+            base64Str = canvas.toDataURL('image/png').split(',')[1];
+            // 送信データ
+            data = {
+                base64_str: base64Str,
+                start_x_position: parseInt(startXPosition),
+                start_y_position: parseInt(startYPosition),
+                width: parseInt(width),
+                height: parseInt(height),
+            }
+            // APIリクエスト
+            fetch('/api/v1/filter/mosaic', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(data),
+            })
+            .then((response) => response.json())
+            .then((data) => {console.log(data.image_base64);image.src = 'data:image/png;base64,' + data.image_base64})
+            .catch((error) => {console.log(error)})
+        }
 </script>
 </html>

--- a/python/src/image.py
+++ b/python/src/image.py
@@ -3,14 +3,14 @@ import cv2
 import numpy
 
 # imageを拡大縮小する関数
-def scalling(image: numpy.ndarray, ratio: int) -> numpy.ndarray:
-    return cv2.resize(image, None, None, ratio, ratio, cv2.INTER_NEAREST)
+def scalling(image: numpy.ndarray, width: int, height: int) -> numpy.ndarray:
+    return cv2.resize(image, (width, height), interpolation=cv2.INTER_NEAREST)
 
 # imageの一部にscalling関数を適用する
 def mosaic_image(origin_image: numpy.ndarray, x: int, y: int, width: int, height: int):
     image = origin_image.copy()
     roi = image[y:y + height, x:x + width] # (y軸, x軸)の順。ROIはRegion Of Interest
-    roi = scalling(scalling(roi, 0.1),10) # 0.1倍縮小程度がちょうどよさそう
+    roi = scalling(scalling(roi, round(width * 0.1), round(height * 0.1)), width, height)  # 0.1倍縮小程度がちょうどよさそう
     image[y:y + height, x:x + width] = roi
     return image
 

--- a/python/src/route.py
+++ b/python/src/route.py
@@ -1,3 +1,4 @@
+import cv2
 from fastapi import FastAPI
 from pydantic import BaseModel
 from image import base64_to_ndarray, mosaic_image, ndarray_to_base64
@@ -14,6 +15,6 @@ class filterParametars(BaseModel):
 @app.post("/api/v1/filter/mosaic")
 async def mosaic_fileter(param: filterParametars):
     image_ndarray = base64_to_ndarray(param.base64_str)
-    modified_image = mosaic_image(image_ndarray, param.start_x_position ,param.start_y_position ,param.width,param.height)
+    modified_image = mosaic_image(image_ndarray, param.start_x_position, param.start_y_position, param.width, param.height)
     base64_str = ndarray_to_base64(modified_image)
     return {"image_base64": base64_str}


### PR DESCRIPTION
モザイクフィルターAPIへのリクエスト処理を実装いたしました。
Base64で画像データを送信し、APIサーバー側でOpenCVで処理を適用してから再度Base64でWebフロントに送信してcanvasに描画を走らせています。

#### アニメーション
![mosaic_pen](https://github.com/hasegawa/easy-mosaic/assets/50223611/073f3741-8e77-4f8f-b4a5-32a8779f41d9)
